### PR TITLE
Bugfix: Project Default Scope Caused project_notifiable to fail

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,7 @@ class User < ActiveRecord::Base
   has_many :provider_users, dependent: :destroy
 
   default_scope { order(:created_at)}
-  scope :project_notifiable, ->(id){ joins(:commented_projects).where(projects: { id: id }, send_notifications: true ) }
+  scope :project_notifiable, ->(id){ joins("INNER JOIN project_comments AS pc ON pc.user_id = users.id INNER JOIN projects AS p ON p.id = pc.project_id").where("p.id = ?", id).where(send_notifications: true ) }
 
 
   # See: https://github.com/zquestz/omniauth-google-oauth2 

--- a/spec/helpers/comment_mailer_helper_spec.rb
+++ b/spec/helpers/comment_mailer_helper_spec.rb
@@ -6,8 +6,8 @@ describe CommentMailerHelper do
     project_owner = create :project_owner, :with_notifications
     comment_user  = create :user, :with_notifications
     comment_users = CommentMailerHelper.get_project_users(project(project_owner, comment_user))
-    expect(comment_users.first).to be project_owner
-    expect(comment_users.last).to be comment_user
+    expect(comment_users.first.id).to eq project_owner.id
+    expect(comment_users.last.id).to eq comment_user.id
   end
   it "does not send emails when email alerts are disabled for everyone" do
     project_owner = create :project_owner, :without_notifications
@@ -19,22 +19,22 @@ describe CommentMailerHelper do
     project_owner = create :project_owner, :with_notifications
     comment_user  = create :user, :without_notifications
     comment_users = CommentMailerHelper.get_project_users(project(project_owner, comment_user))
-    expect(comment_users.first).to be project_owner
+    expect(comment_users.first.id).to eq project_owner.id
     expect(comment_users.length).to eq 1
   end
-
   it "sends an emails when email alerts are enabled only for commenters" do
     project_owner = create :project_owner, :without_notifications
     comment_user  = create :user, :with_notifications
     comment_users = CommentMailerHelper.get_project_users(project(project_owner, comment_user))
-    expect(comment_users.first).to be comment_user
+    expect(comment_users.first.id).to eq comment_user.id
     expect(comment_users.length).to eq 1
   end
 
   private
 
   def project(project_owner, comment_user)
-    project = create(:project, project_owner: project_owner, organization: create(:organization))
+    organization = build(:organization)
+    project = create(:project, project_owner: project_owner, organization: organization)
     project.comments = [create(:project_comment, user: comment_user, project: project)]
     project.save
     project


### PR DESCRIPTION
After a little poking at https://github.com/campuscodefest/ccf/pull/79#issuecomment-164168841, I noticed project was tacking on a 'organization_id' IS NULL to the project_notifiable join conditions. Since Organization.current_id is out of scope in this context and doesn't seem necessary, I decided to write the join logic out a bit more explicitly, forgoing the AR call to :projects. This might be handled another way, but this is one potential fix.