### PR TITLE
Local login

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,15 @@ cd ccf
 bundle
 ```
 
-We use Omniauth to support Google account login. You must generate an OAuth 2.0 API key via Google Developer Console (https://cloud.google.com/console/project), more instructions can be found here: https://developers.google.com/ad-exchange/rtb/open-bidder/google-app-guide#step-5 . Once this is done, copy the example config.yml file and enter your api key and secret to the provider section.
+We use Omniauth to support Google account login. You must generate an OAuth 2.0 API key via Google Developer Console
+(https://cloud.google.com/console/project), more instructions can be found here:
+https://developers.google.com/ad-exchange/rtb/open-bidder/google-app-guide#step-5 . Once this is done, copy the example
+config.yml file and enter your api key and secret to the provider section.
 
-Note: this application rquires a wildcard domain setting. If you simply want to set-up authentication for your local development instance of the ccf app, you simply use the domain `http://lvh.me` instead of http://localhost in your google development console. The http://lvh.me is a domain that was registered as a convenience for developers and resolves to 127.0.0.1 for all requests to http://lvh.me and subdomains thereof.
+Note: this application rquires a wildcard domain setting. If you simply want to set-up authentication for your local
+development instance of the ccf app, you simply use the domain `http://lvh.me` instead of http://localhost in your
+google development console. The http://lvh.me is a domain that was registered as a convenience for developers and
+resolves to 127.0.0.1 for all requests to http://lvh.me and subdomains thereof.
 
 For local development, the Omniauth 'developer' provider is enabled and allows you to log in without setting up any
 other provider API keys. Add `127.0.0.1 lvh.me` to `/etc/hosts` to work offline.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ We use Omniauth to support Google account login. You must generate an OAuth 2.0 
 
 Note: this application rquires a wildcard domain setting. If you simply want to set-up authentication for your local development instance of the ccf app, you simply use the domain `http://lvh.me` instead of http://localhost in your google development console. The http://lvh.me is a domain that was registered as a convenience for developers and resolves to 127.0.0.1 for all requests to http://lvh.me and subdomains thereof.
 
+For local development, the Omniauth 'developer' provider is enabled and allows you to log in without setting up any
+other provider API keys. Add `127.0.0.1 lvh.me` to `/etc/hosts` to work offline.
+
 ```
 cp config/config.yml.example config/config.yml
 ```

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::Base
     @current_user ||= User.email_confirmed.find_by_id(session[:user_id]) if session[:user_id]
     @current_user
   end
-  helper_method :current_user
+  helper_method :current_user, :allow_development_provider?
 
   def alerts
     return nil unless current_user
@@ -35,5 +35,9 @@ class ApplicationController < ActionController::Base
     session[:token] = nil
     session[:created_at] = nil
     session[:email_required] = nil
+  end
+
+  def allow_development_provider?
+    Rails.env.development? || Rails.env.test?
   end
 end

--- a/app/views/layouts/common/_sign_in.html.erb
+++ b/app/views/layouts/common/_sign_in.html.erb
@@ -19,6 +19,12 @@
           Sign in with Meetup
         <% end %>
         <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+        <% if allow_development_provider? %>
+          <br/><br/>
+          <%= link_to '/auth/developer' do %>
+            Development login
+          <% end %>
+        <% end %>
       </div>
     </div>
   </div>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -8,5 +8,9 @@ if !config.empty?
     provider :google_oauth2, config["providers"]["google_oauth2"]["key"], config["providers"]["google_oauth2"]["secret"], {client_options: {ssl: {ca_path: "/usr/lib/ssl/certs"}}, setup: true}
     provider :facebook, config["providers"]["facebook"]["key"], config["providers"]["facebook"]["secret"], { scope: 'email', info_fields: 'email'}
     provider :meetup, config["providers"]["meetup"]["key"], config["providers"]["meetup"]["secret"]
+
+    if Rails.env.development? || Rails.env.test?
+      provider :developer
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,8 @@ CampusCodefest::Application.routes.draw do
   get 'contact' => 'contact#new', :as => 'contact'
   post 'contact' => 'contact#create', :as => 'contact_create'
 
-  get "/auth/:provider/callback" => "sessions#create"
+  get  "/auth/:provider/callback" => "sessions#create"
+  post "/auth/:provider/callback" => "sessions#create"
   get "/signout" => "sessions#signout", :as => :signout
 
   # Organization routes

--- a/spec/controllers/sessions_spec.rb
+++ b/spec/controllers/sessions_spec.rb
@@ -21,6 +21,15 @@ describe SessionsController, type: :controller do
       auth.credentials!.token = '1234'
       auth
     end
+    let(:auth_developer) do
+      auth = Hashie::Mash.new
+      auth.provider = 'developer'
+      auth.uid = 2
+      auth.info!.name = 'Tester'
+      auth.info.email = 'tester@address.com'
+      auth.credentials!.token = '1234'
+      auth
+    end
     before(:each) do
       @request.env['omniauth.params'] = {'register_for_event_id' => nil}
       @request.env['omniauth.origin'] = nil
@@ -36,6 +45,14 @@ describe SessionsController, type: :controller do
       @request.env["omniauth.auth"] = auth_with_email
       post :create
       expect(response).to redirect_to root_url 
+    end
+
+    it "should log in a developer" do
+      @request.env["omniauth.auth"] = auth_developer
+      post :create
+      expect(response).to redirect_to root_url
+      user = User.find_by_id!(session[:user_id])
+      expect(user.email).to eq("tester@address.com")
     end
   end
 end


### PR DESCRIPTION
Adds the `developer` Omniauth provider.

1. enables in development and testing environments

2. turns of authenticity check in sessions controller for development; this fixes a bug where the developer provider does not appear to set the correct CSRF token

3. developer provider accounts are automatically confirmed

4. adds a 'Development login' link in the sign-in box

5. adds note to README (also reformat previous paragraphs to fit a 120-char width like the rest of the file)