### PR TITLE
hide unpublished presentations from non-owners

### DIFF
--- a/app/views/projects/_project.html.erb
+++ b/app/views/projects/_project.html.erb
@@ -5,10 +5,8 @@
       <% unless @event.nil? && project.event.nil? %>
         <% if can?(:edit, project.presentation) || project.presentation.published %>
           <%=link_to project_presentation_path(project), class: "btn btn-primary btn-sm" do%>
-            <i class="fa fa-play"></i> Presentation
+            <i class="fa fa-play"></i> Presentation <%= '(Unpublished)' if (!project.presentation.published) %>
           <% end %>
-        <% elsif %>
-        <a href="#" class="btn btn-primary" disabled="disabled"><i class="fa fa-play"></i> Presentation</a>
         <% end %>
       <% end %>
     </p>


### PR DESCRIPTION
I swung by geo-code and folks were fairly confused about not being able to click the unpublished presentation button. Seems like we should just hide it from anyone without editing privileges. I also added an indicator for those that can edit/publish as to the status of the presentation when unpublished.